### PR TITLE
steering: allow passing already-resolved json-like python object

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,6 @@
 import pytest
 import yadage.workflow_loader
+import jsonschema.exceptions
 
 def test_load_hello_world():
 	yadage.workflow_loader.workflow('workflow.yml','tests/testspecs/local-helloworld')
@@ -7,3 +8,9 @@ def test_load_hello_world():
 def test_load_failt():
 	with pytest.raises(RuntimeError):
 		yadage.workflow_loader.workflow('non_existent.yml','tests/testspecs/local-helloworld')
+
+
+
+def test_validate_fail():
+	with pytest.raises(jsonschema.exceptions.ValidationError):
+		yadage.workflow_loader.validate({})

--- a/tests/test_maincli.py
+++ b/tests/test_maincli.py
@@ -36,4 +36,3 @@ def test_maincli_interactive_no_yes(tmpdir):
     )
     assert tmpdir.join('workdir/hello_world/hello_world.txt').check()
     assert result.exit_code == 0
-

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import jsonschema.exceptions
 import yadage.workflow_loader
 from yadage.steering_object import YadageSteering
 from yadage.steering_api import steering_ctx
@@ -50,6 +51,13 @@ def test_directjson(tmpdir,multiproc_backend):
     ys.run_adage(multiproc_backend)
 
     assert tmpdir.join('workdir/hello_world/hello_world.txt').check()
+
+def test_invalid_directjson():
+    wflowjson = yadage.workflow_loader.workflow('workflow.yml','tests/testspecs/local-helloworld')
+    ys = YadageSteering()
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        ys.init_workflow(workflow_json = {'invalid':'data'})
+
 
 def test_directjson_ctx(tmpdir,multiproc_backend):
     wflowjson = yadage.workflow_loader.workflow('workflow.yml','tests/testspecs/local-helloworld')

--- a/yadage/steering_api.py
+++ b/yadage/steering_api.py
@@ -21,10 +21,11 @@ def run_workflow(*args, **kwargs):
 @contextmanager
 def steering_ctx(
     dataarg,
-    workflow,
+    workflow = None,
     initdata = None,
     toplevel = os.getcwd(),
     backend = None,
+    workflow_json = None,
     cache = None,
     dataopts = None,
     updateinterval = 0.02,
@@ -55,12 +56,18 @@ def steering_ctx(
         dataopts = dataopts
     )
 
+    wflow_kwargs = dict() #if this stays empty, error will be raise by ys
+    if workflow_json:
+        wflow_kwargs = dict(workflow_json = workflow_json)
+    elif workflow:
+        wflow_kwargs = dict(workflow = workflow, toplevel = toplevel, validate = validate, schemadir = schemadir)
+
     ys.init_workflow(
-        workflow = workflow, toplevel = toplevel, validate = validate, schemadir = schemadir,
         initdata = initdata,
         statesetup = statesetup,
+        **wflow_kwargs
     )
-    
+
     custom_tracker = os.environ.get('YADAGE_CUSTOM_TRACKER',None)
     if custom_tracker:
         modulename,trackerclassname = custom_tracker.split(':')
@@ -79,10 +86,10 @@ def steering_ctx(
             extend_decider = extend,
             submit_decider = submit
         )
-            
+
     yield ys
- 
-    backend = backend or setupbackend_fromstring('multiproc:auto')   
+
+    backend = backend or setupbackend_fromstring('multiproc:auto')
     log.info('running yadage workflow %s on backend %s', workflow, backend)
     if cache:
         if cache == 'checksums':

--- a/yadage/steering_object.py
+++ b/yadage/steering_object.py
@@ -118,13 +118,17 @@ class YadageSteering():
         if not workflow_json and not workflow:
             raise RuntimeError('need to provide either direct workflow spec or source to load from')
 
-        if not workflow_json:
+        if workflow_json:
+            if validate: workflow_loader.validate(workflow_json)
+        else:
             workflow_json = workflow_loader.workflow(
                 workflow,
                 toplevel=toplevel,
                 schemadir=schemadir,
                 validate=validate
             )
+
+
         with open('{}/yadage_template.json'.format(self.metadir), 'w') as f:
             json.dump(workflow_json, f)
         workflowobj = YadageWorkflow.createFromJSON(workflow_json, self.rootprovider)

--- a/yadage/steering_object.py
+++ b/yadage/steering_object.py
@@ -53,9 +53,9 @@ class YadageSteering():
     def prepare_localstate(self, dataarg, dataopts, initdata = None):
         '''
         prepare default local state provider
-        
+
         :param dataarg: the workdirectory under which all packtivity data will be stored
-        :param dataopts: dictionary 
+        :param dataopts: dictionary
         :param initdata: initdata tempalte that is mutated based on initialization data on disk
         '''
         workdir = dataarg
@@ -81,10 +81,10 @@ class YadageSteering():
         prepares workflow data state, with  possible initialization and sets up stateprovider used for workflow stages.
         if initialization data is provided, it may be mutated to reflect automatic data discovery
 
-        :param dataarg: mandatory state provider setup. generally <datatype>:<argument>. For 
+        :param dataarg: mandatory state provider setup. generally <datatype>:<argument>. For
         :param dataopts: optional settings for state provider
         :param initdata: optional workflow init parameters to process against data setup
-        :param accept_metadir: 
+        :param accept_metadir:
         :param metadir: meta-data directory
         '''
         self.metadir = metadir
@@ -94,25 +94,37 @@ class YadageSteering():
             dataarg = split_dataarg[0]
             self.prepare_localstate(dataarg,dataopts,initdata)
         else:
-            assert self.metadir #for non-default provider, require metadir to be set 
+            assert self.metadir #for non-default provider, require metadir to be set
             datatype, dataarg = split_dataarg
             self.rootprovider = utils.setupstateprovider(datatype, dataarg, dataopts)
         self.prepare_meta(accept = accept_metadir)
-                
-    def init_workflow(self, workflow, initdata = None, toplevel = os.getcwd(), statesetup = 'inmem', validate = True, schemadir = yadageschemas.schemadir):
+
+    def init_workflow(self,
+                      workflow = None,
+                      initdata = None,
+                      toplevel = os.getcwd(),
+                      workflow_json = None,
+                      statesetup = 'inmem',
+                      validate = True,
+                      schemadir = yadageschemas.schemadir):
         '''
         load workflow from spec and initialize it
-        
+
         :param workflow: the workflow spec source
         :param toplevel: base URI against which to resolve JSON references in the spec
-        :param initdata: initialization data for workflow 
+        :param initdata: initialization data for workflow
         '''
-        workflow_json = workflow_loader.workflow(
-            workflow,
-            toplevel=toplevel,
-            schemadir=schemadir,
-            validate=validate
-        )
+
+        if not workflow_json and not workflow:
+            raise RuntimeError('need to provide either direct workflow spec or source to load from')
+
+        if not workflow_json:
+            workflow_json = workflow_loader.workflow(
+                workflow,
+                toplevel=toplevel,
+                schemadir=schemadir,
+                validate=validate
+            )
         with open('{}/yadage_template.json'.format(self.metadir), 'w') as f:
             json.dump(workflow_json, f)
         workflowobj = YadageWorkflow.createFromJSON(workflow_json, self.rootprovider)
@@ -143,7 +155,7 @@ class YadageSteering():
     def serialize(self):
         '''
         serialized workflow and backend states (stored in meta directory)
-        ''' 
+        '''
         serialize.snapshot(
             self.workflow,
             '{}/yadage_snapshot_workflow.json'.format(self.metadir),
@@ -157,4 +169,3 @@ class YadageSteering():
         import yadage.visualize as visualize
         visualize.write_prov_graph(self.metadir, self.workflow, vizformat='png')
         visualize.write_prov_graph(self.metadir, self.workflow, vizformat='pdf')
-

--- a/yadage/workflow_loader.py
+++ b/yadage/workflow_loader.py
@@ -1,5 +1,15 @@
 import yadageschemas
 
 def workflow(source, toplevel, schema_name='yadage/workflow-schema', schemadir=None, validate=True):
+    '''
+    load (and validate) workflow from source
+    param source: URI fragment to the source
+    param toplevel: base URI to resolve references from
+    schemadir
+    '''
     data = yadageschemas.load(source, toplevel, schema_name, schemadir, validate)
     return data
+
+def validate(data, schema_name='yadage/workflow-schema', schemadir=None):
+    '''validate workflow data'''
+    yadageschemas.validator(schema_name,schemadir).validate(data)


### PR DESCRIPTION
* allows runinng workflows without explicit loading / validatio when workflow spec is already in-memory