### PR TITLE
automatically detect pub only task

### DIFF
--- a/tests/testspecs/nested/subflow.yml
+++ b/tests/testspecs/nested/subflow.yml
@@ -6,3 +6,16 @@ stages:
       parameters:
         inputpar: {stages: init, output: inputpar, unwrap: true}
       workflow: {$ref: subsubflow.yml}
+  - name: output
+    dependencies: ['morenested']
+    scheduler:
+      scheduler_type: singlestep-stage
+      parameters:
+        input: {stages: 'morenested[*].stage1', output: outputA, unwrap: true}
+      step:
+        process: null
+        environment: null
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            wellKnown: 'input'

--- a/tests/testspecs/nested/workflow.yml
+++ b/tests/testspecs/nested/workflow.yml
@@ -11,5 +11,5 @@ stages:
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        input: {stages: 'nested[0].morenested[0].stage1', output: outputA}
+        input: {stages: 'nested[0].output', output: wellKnown}
       step: {$ref: steps.yml#/stepA}

--- a/yadage/backends/packtivitybackend.py
+++ b/yadage/backends/packtivitybackend.py
@@ -39,7 +39,6 @@ class PacktivityBackend(federatedbackend.FederatedBackend):
 
     def routedsubmit(self, task):
         is_pure_publishing = task.metadata['wflow_hints'].get('is_purepub',False)
-
         if is_pure_publishing:
             foreground_proxy = self.backends['purepub'].submit(
                 task.spec, task.parameters, task.state, task.metadata

--- a/yadage/handlers/scheduler_handlers.py
+++ b/yadage/handlers/scheduler_handlers.py
@@ -321,4 +321,4 @@ def init_stage(stage, spec):
     task = packtivity_task(spec['nodename'] or stage.name, init_spec, step_state)
     task.s(**spec['parameters'])
     task.used_inputs(inputs)
-    stage.addStep(task, hints = {'is_purepub': True})
+    stage.addStep(task)

--- a/yadage/stages.py
+++ b/yadage/stages.py
@@ -96,9 +96,9 @@ class ViewStageBase(object):
         self.view = flowview
         self.schedule()
 
-    def addStep(self, step, hints = None):
+    def addStep(self, step):
         dependencies = [self.view.dag.getNode(k.stepid) for k in step.inputs]
-        return self.view.addStep(step, stage = self.name, depends_on=dependencies, hints = hints)
+        return self.view.addStep(step, stage = self.name, depends_on=dependencies)
 
     def addWorkflow(self, rules, isolate = True):
         self.view.addWorkflow(rules, stage=self.name if isolate else None)

--- a/yadage/steering_api.py
+++ b/yadage/steering_api.py
@@ -96,7 +96,6 @@ def steering_ctx(
             backend.enable_cache(':'.join([cache,os.path.join(ys.metadir,'cache.json')]))
         else:
             backend.enable_cache(cache)
-
     try:
         ys.run_adage(backend)
     finally:

--- a/yadage/tasks.py
+++ b/yadage/tasks.py
@@ -35,6 +35,9 @@ class packtivity_task(TaskBase):
         self.spec = spec
         self.state = state
 
+    def pubOnlyTask(self):
+        return (self.spec['environment'] is None) and (self.spec['process'] is None)
+
     def s(self, **parameters):
         self.parameters.update(**parameters)
         if self.state:

--- a/yadage/visualize.py
+++ b/yadage/visualize.py
@@ -41,10 +41,10 @@ def fillscope(cluster, workflow, scope='', subcluster=True):
             if '_nodeid' in element:
                 element = element['_nodeid']
                 targetcl = stagecluster if stage != 'init' else scopecluster
-                shape = 'diamond' if stage == 'init' else 'box'
-                label = '' if stage == 'init' else '{}[{}]'.format(stage, i)
+                shape = 'diamond' if stage in ['init','output'] else 'box'
+                label = '' if stage in ['init','output'] else '{}[{}]'.format(stage, i)
                 additional = {'fixedsize': True, 'height': 0.2,
-                              'width': 0.2} if stage == 'init' else {}
+                              'width': 0.2} if stage in ['init','output'] else {}
                 targetcl.add_node(pydotplus.graphviz.Node(
                     element, label=label, color='blue', shape=shape, **additional))
                 add_result(targetcl, element,


### PR DESCRIPTION
* added property in packtivity_task to determine if a task is a read-only/pub-only task
* allows for adding generic "expression" nodes that do not add data and get executed on the
  pubonly backend porition (fast)