### PR TITLE
generalize --interactive

### DIFF
--- a/tests/test_maincli.py
+++ b/tests/test_maincli.py
@@ -24,7 +24,7 @@ def test_maincli_initfile(tmpdir):
 def test_maincli_interactive_all_yes(tmpdir):
     runner = CliRunner()
     result = runner.invoke(yadage.steering.main,[
-        os.path.join(str(tmpdir),'workdir'),'workflow.yml','-t','tests/testspecs/local-helloworld','--interactive','-p','par=value'], input = 'y\ny\ny\ny\ny\ny\n'
+        os.path.join(str(tmpdir),'workdir'),'workflow.yml','-t','tests/testspecs/local-helloworld','-g','interactive','-p','par=value'], input = 'y\ny\ny\ny\ny\ny\n'
     )
     assert tmpdir.join('workdir/hello_world/hello_world.txt').check()
     assert result.exit_code == 0
@@ -32,7 +32,7 @@ def test_maincli_interactive_all_yes(tmpdir):
 def test_maincli_interactive_no_yes(tmpdir):
     runner = CliRunner()
     result = runner.invoke(yadage.steering.main,[
-        os.path.join(str(tmpdir),'workdir'),'workflow.yml','-t','tests/testspecs/local-helloworld','--interactive','-p','par=value'], input = 'y\ny\ny\ny\ny\ny\n'
+        os.path.join(str(tmpdir),'workdir'),'workflow.yml','-t','tests/testspecs/local-helloworld','-g','interactive','-p','par=value'], input = 'y\ny\ny\ny\ny\ny\n'
     )
     assert tmpdir.join('workdir/hello_world/hello_world.txt').check()
     assert result.exit_code == 0

--- a/yadage/interactive.py
+++ b/yadage/interactive.py
@@ -1,4 +1,5 @@
 import click
+from .utils import advance_coroutine
 
 def decide_rule(rule, controller, idbased):
     click.secho('we could extend DAG with rule', fg='blue')
@@ -52,12 +53,7 @@ def custom_decider(decide_func, idbased):
             data = yield decide_func(*data, idbased = idbased)
     return decider
 
-def advance_coroutine(coroutine):
-    try:
-        return coroutine.next()
-    except AttributeError:
-        return coroutine.__next__()
-   
+
 
 def interactive_deciders(idbased = False):
     '''

--- a/yadage/manualcli.py
+++ b/yadage/manualcli.py
@@ -272,10 +272,10 @@ def handle_connection_options(metadir, accept_metadir, controller, ctrlopt, mode
 @click.option('--track/--no-track', default=True)
 @click.option('-n', '--nsteps', default=-1, help = 'number of steps to process. use -1 to for no limit (will run workflow to completion)')
 @click.option('-u', '--update-interval', default=1)
-@click.option('--interactive/--not-interactive', default=False, help = 'en-/disable user interactio (sign-off graph extensions and packtivity submissions)')
+@click.option('-g','--strategy', help = 'set execution stragegy')
 @connection_options
 @common_options
-def step(track , interactive, nsteps, update_interval,
+def step(track , strategy, nsteps, update_interval,
          metadir, accept_metadir, controller, ctrlopt, modelsetup, modelopt, backend, local,
          verbosity
          ):
@@ -287,7 +287,7 @@ def step(track , interactive, nsteps, update_interval,
         ys,
         updateinterval = update_interval,
         default_trackers = track,
-        interactive = interactive
+        strategy = strategy
     )
 
 @mancli.command()

--- a/yadage/steering.py
+++ b/yadage/steering.py
@@ -20,6 +20,7 @@ RC_SUCCEEDED = 0
 @click.option('-c', '--cache', default='')
 @click.option('-d', '--dataopt', multiple=True, default=None, help = 'options for the workflow data state')
 @click.option('-e', '--schemadir', default=yadageschemas.schemadir, help = 'schema directory for workflow validation')
+@click.option('-g', '--strategy', help = 'set execution stragegy')
 @click.option('-i', '--loginterval', default=30, help = 'adage tracking interval in seconds')
 @click.option('-k', '--backendopt', multiple=True, default=None, help = 'options for the workflow data state')
 @click.option('-l', '--modelopt', multiple=True, default=None, help = 'options for the workflow state models')
@@ -33,7 +34,6 @@ RC_SUCCEEDED = 0
 @click.option('-v', '--verbosity', default='INFO', help = 'logging verbosity')
 @click.option('--accept-metadir/--no-accept-metadir', default=False)
 @click.option('--plugins', default=None)
-@click.option('--interactive/--not-interactive', default=False, help = 'en-/disable user interactio (sign-off graph extensions and packtivity submissions)')
 @click.option('--validate/--no-validate', default=True, help = 'en-/disable workflow spec validation')
 @click.option('--visualize/--no-visualize', default=False, help = 'visualize workflow graph')
 def main(dataarg,
@@ -49,7 +49,7 @@ def main(dataarg,
          backend,
          dataopt,
          backendopt,
-         interactive,
+         strategy,
          modelsetup,
          modelopt,
          metadir,
@@ -97,7 +97,7 @@ def main(dataarg,
             updateinterval = updateinterval,
             loginterval = loginterval,
             visualize = visualize,
-            interactive = interactive,
+            strategy = strategy,
         )
         rc = RC_SUCCEEDED
     except:

--- a/yadage/steering_api.py
+++ b/yadage/steering_api.py
@@ -5,7 +5,7 @@ import yadageschemas
 import os
 
 from .steering_object import YadageSteering
-from .interactive import interactive_deciders
+from .strategies import get_strategy
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def execute_steering(
     updateinterval = 0.02,
     loginterval = 30,
     default_trackers=True,
-    interactive = False,
+    strategy = None,
     backend = None,
     cache = None
     ):
@@ -48,12 +48,8 @@ def execute_steering(
         trackerclass = getattr(module,trackerclassname)
         ys.adage_argument(additional_trackers = [trackerclass()])
 
-    if interactive:
-        extend, submit = interactive_deciders()
-        ys.adage_argument(
-            extend_decider = extend,
-            submit_decider = submit
-        )
+    if strategy is not None:
+        ys.adage_argument(**get_strategy(strategy))
 
     ys.run_adage(backend)
 
@@ -73,7 +69,7 @@ def steering_ctx(
     loginterval = 30,
     schemadir = yadageschemas.schemadir,
     metadir = None,
-    interactive=False,
+    strategy=None,
     validate=True,
     visualize=True,
     accept_metadir = False,
@@ -100,7 +96,7 @@ def steering_ctx(
             updateinterval = updateinterval,
             loginterval = loginterval,
             default_trackers = visualize,
-            interactive = interactive,
+            strategy = strategy,
             backend = backend,
             cache = cache
         )

--- a/yadage/strategies.py
+++ b/yadage/strategies.py
@@ -1,0 +1,34 @@
+from adage.pollingexec import yes_man
+from .interactive import interactive_deciders, custom_decider, decide_step
+from .utils import advance_coroutine
+
+strategies = {}
+def strategy(name):
+    def wrap(func):
+        strategies[name] = func
+        return func
+    return wrap
+
+def get_strategy(name):
+    return strategies[name]()
+
+@strategy('interactive')
+def interactive_strategy():
+    extend, submit = interactive_deciders()
+    return dict(
+            extend_decider = extend,
+            submit_decider = submit
+    )
+
+@strategy('askforsubmit')
+def askforsubmit():
+    extend_decider = yes_man()
+    advance_coroutine(extend_decider)
+
+    submit_decider = custom_decider(decide_step, idbased = False)()
+    advance_coroutine(submit_decider)
+
+    return dict(
+            extend_decider = extend_decider,
+            submit_decider = submit_decider
+    )

--- a/yadage/utils.py
+++ b/yadage/utils.py
@@ -261,3 +261,9 @@ def rule_steps_indices(workflow):
         for step in steps_of_rule:
             steps_to_rule_index[step] = rule.identifier
     return rule_to_steps_index, steps_to_rule_index
+
+def advance_coroutine(coroutine):
+    try:
+        return coroutine.next()
+    except AttributeError:
+        return coroutine.__next__()


### PR DESCRIPTION
* based on the generic coroutine-based polling execution system of adage
  this introduces a new flag -g / --strategy that lets you select one of
  multiple steering stategies on how to process the DAG

* one use-case is a target-focused strategy where the only nodes that
  are processed are those necessary to reach a certain 'target node'